### PR TITLE
SCRUM-17: Cancel pending WFH arrangement

### DIFF
--- a/backend/api/routes/arrangementRequestsRoutes.js
+++ b/backend/api/routes/arrangementRequestsRoutes.js
@@ -6,7 +6,8 @@ import {
   createRegArrangementRequests,
   getOwnSchedule,
   getTeamSchedule,
-  withdrawStaffRequests
+  withdrawStaffRequests,
+  cancelStaffRequests
 } from "../controllers/arrangementRequestsController.js";
 
 const router = express.Router();
@@ -18,5 +19,6 @@ router.post("/reg", createRegArrangementRequests);
 router.get("/myschedule", getOwnSchedule);
 router.get("/teamschedule", getTeamSchedule);
 router.patch('/staffwithdrawal', withdrawStaffRequests);
+router.patch('/staffcancellation', cancelStaffRequests);
 
 export default router;

--- a/backend/scripts/functional_test/tc_017_01.js
+++ b/backend/scripts/functional_test/tc_017_01.js
@@ -1,0 +1,116 @@
+import { connectDB, currentTestDB } from "./db_test_start.js";
+import teardownDB from "./db_test_end.js";
+import ArrangementRequest from "../../api/models/arrangementRequestsModel.js";
+import Staff from "../../api/models/staffModel.js";
+import app from "./backend_start.js";
+
+console.log("Running!");
+
+(async () => {
+  await connectDB("017_01");
+
+  await populateData();
+
+  const server = app.listen(process.env.PORT, () => {
+    console.log(`Server ready on port ${process.env.PORT}`);
+  });
+
+  const shutdown = async () => {
+    console.log("Shutting down...");
+    await teardownDB(currentTestDB);
+    server.close(() => {
+      console.log("Server closed");
+      process.exit(0);
+    });
+  };
+
+  // Listen for SIGINT and SIGTERM signals
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+})();
+
+const populateData = async () => {
+  await Promise.all([populateStaff(), populateRequest()]);
+};
+
+const populateRequest = async () => {
+    try {
+      const today = new Date();
+      
+      const tomorrow = new Date(today);
+      tomorrow.setDate(today.getDate() + 1);
+  
+      const nextWeek = new Date(today);
+      nextWeek.setDate(today.getDate() + 7);
+  
+      // Format the dates
+      const formattedTomorrow = tomorrow
+        .toLocaleDateString("en-CA", {
+          timeZone: "Asia/Singapore",
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+        })
+        .split("-")
+        .join("-");
+  
+      const formattedNextWeek = nextWeek
+        .toLocaleDateString("en-CA", {
+          timeZone: "Asia/Singapore",
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+        })
+        .split("-")
+        .join("-");
+  
+      const requests = [
+        {
+          staff_id: 140081,
+          request_date: formattedTomorrow,
+          status: "Pending",
+          manager_id: 140001,
+          request_time: "AM",
+          reason: "Child carer",
+          group_id: "12031203910249",
+        },
+        {
+          staff_id: 140081,
+          request_date: formattedNextWeek,
+          status: "Pending",
+          manager_id: 140001,
+          request_time: "AM",
+          reason: "Child carer",
+          group_id: "12031203910249",
+        },
+      ];
+  
+      await ArrangementRequest.insertMany(requests);
+      console.log("Request data inserted successfully");
+    } catch (error) {
+      console.error("Error inserting request data:", error);
+    }
+  };
+  
+
+const populateStaff = async () => {
+  try {
+    const staffArr = [
+      {
+        staff_id: 140081,
+        staff_fname: "Rahim",
+        staff_lname: "Khalid",
+        dept: "Sales",
+        position: "Sales Manager",
+        country: "Singapore",
+        email: "Rahim.khalid@allinone.com.sg",
+        reporting_manager: 160008,
+        role: 3,
+      },
+    ];
+    await Staff.insertMany(staffArr);
+    console.log("Staff data inserted successfully");
+  } catch (error) {
+    console.error("Error inserting staff data:", error);
+  }
+};

--- a/backend/scripts/functional_test/tc_017_02.js
+++ b/backend/scripts/functional_test/tc_017_02.js
@@ -1,0 +1,87 @@
+import { connectDB, currentTestDB } from "./db_test_start.js";
+import teardownDB from "./db_test_end.js";
+import ArrangementRequest from "../../api/models/arrangementRequestsModel.js";
+import Staff from "../../api/models/staffModel.js";
+import app from "./backend_start.js";
+
+console.log("Running!");
+
+(async () => {
+  await connectDB("017_02");
+
+  await populateData();
+
+  const server = app.listen(process.env.PORT, () => {
+    console.log(`Server ready on port ${process.env.PORT}`);
+  });
+
+  const shutdown = async () => {
+    console.log("Shutting down...");
+    await teardownDB(currentTestDB);
+    server.close(() => {
+      console.log("Server closed");
+      process.exit(0);
+    });
+  };
+
+  // Listen for SIGINT and SIGTERM signals
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+})();
+
+const populateData = async () => {
+  await Promise.all([populateStaff(), populateRequest()]);
+};
+
+const populateRequest = async () => {
+  try {
+    const today = new Date();
+    today.setDate(today.getDate() + 1);
+    const tomorrow = today
+      .toLocaleDateString("en-CA", {
+        timeZone: "Asia/Singapore",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      })
+      .split("-")
+      .join("-");    
+    const requests = [
+      {
+        staff_id: 140081,
+        request_date: tomorrow,
+        status: "Pending",
+        manager_id: 140001,
+        request_time: "AM",
+        reason: "Child carer",
+      }
+    ];
+
+    await ArrangementRequest.insertMany(requests);
+    console.log("Request data inserted successfully");
+  } catch (error) {
+    console.error("Error inserting request data:", error);
+  }
+};
+
+const populateStaff = async () => {
+  try {
+    const staffArr = [
+      {
+        staff_id: 140081,
+        staff_fname: "Rahim",
+        staff_lname: "Khalid",
+        dept: "Sales",
+        position: "Sales Manager",
+        country: "Singapore",
+        email: "Rahim.khalid@allinone.com.sg",
+        reporting_manager: 160008,
+        role: 3,
+      }
+    ];
+    await Staff.insertMany(staffArr);
+    console.log("Staff data inserted successfully");
+  } catch (error) {
+    console.error("Error inserting staff data:", error);
+  }
+};

--- a/backend/scripts/functional_test/tc_017_04.js
+++ b/backend/scripts/functional_test/tc_017_04.js
@@ -1,0 +1,180 @@
+import { connectDB, currentTestDB } from "./db_test_start.js";
+import teardownDB from "./db_test_end.js";
+import ArrangementRequest from "../../api/models/arrangementRequestsModel.js";
+import Staff from "../../api/models/staffModel.js";
+import app from "./backend_start.js";
+
+console.log("Running!");
+
+(async () => {
+  await connectDB("017_05");
+
+  await populateData();
+
+  const server = app.listen(process.env.PORT, () => {
+    console.log(`Server ready on port ${process.env.PORT}`);
+  });
+
+  const shutdown = async () => {
+    console.log("Shutting down...");
+    await teardownDB(currentTestDB);
+    server.close(() => {
+      console.log("Server closed");
+      process.exit(0);
+    });
+  };
+
+  // Listen for SIGINT and SIGTERM signals
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+})();
+
+const populateData = async () => {
+  await Promise.all([populateStaff(), populateRequest()]);
+};
+
+const populateRequest = async () => {
+  try {
+    const today = new Date();
+
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+
+    const formattedTomorrow = tomorrow
+      .toLocaleDateString("en-CA", {
+        timeZone: "Asia/Singapore",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      })
+      .split("-")
+      .join("-");
+
+    const two_days = new Date(today);
+    two_days.setDate(today.getDate() + 2);
+
+    const formattedTwoDays = two_days
+      .toLocaleDateString("en-CA", {
+        timeZone: "Asia/Singapore",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      })
+      .split("-")
+      .join("-");
+
+    const three_days = new Date(today);
+    three_days.setDate(today.getDate() + 3);
+
+    const formattedThreeDays = three_days
+      .toLocaleDateString("en-CA", {
+        timeZone: "Asia/Singapore",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      })
+      .split("-")
+      .join("-");
+
+    const four_days = new Date(today);
+    four_days.setDate(today.getDate() + 4);
+
+    const formattedFourDays = four_days
+      .toLocaleDateString("en-CA", {
+        timeZone: "Asia/Singapore",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      })
+      .split("-")
+      .join("-");
+
+    const five_days = new Date(today);
+    five_days.setDate(today.getDate() + 5);
+
+    const formattedFiveDays = five_days
+      .toLocaleDateString("en-CA", {
+        timeZone: "Asia/Singapore",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      })
+      .split("-")
+      .join("-");
+
+    const requests = [
+      {
+        staff_id: 140081,
+        request_date: formattedTomorrow,
+        status: "Approved",
+        manager_id: 140001,
+        request_time: "AM",
+        reason: "Child carer",
+        group_id: null,
+      },
+      {
+        staff_id: 140081,
+        request_date: formattedTwoDays,
+        status: "Rejected",
+        manager_id: 140001,
+        request_time: "AM",
+        reason: "COVID-19",
+        group_id: null,
+      },
+      {
+        staff_id: 140081,
+        request_date: formattedThreeDays,
+        status: "Cancelled",
+        manager_id: 140001,
+        request_time: "AM",
+        reason: "COVID-20",
+        group_id: null,
+      },
+      {
+        staff_id: 140081,
+        request_date: formattedFourDays,
+        status: "Pending Withdrawal",
+        manager_id: 140001,
+        request_time: "AM",
+        reason: "COVID-21",
+        group_id: null,
+      },
+      {
+        staff_id: 140081,
+        request_date: formattedFiveDays,
+        status: "Withdrawn",
+        manager_id: 140001,
+        request_time: "AM",
+        reason: "COVID-78",
+        group_id: null,
+      }
+    ];
+
+    await ArrangementRequest.insertMany(requests);
+    console.log("Request data inserted successfully");
+  } catch (error) {
+    console.error("Error inserting request data:", error);
+  }
+};
+
+const populateStaff = async () => {
+  try {
+    const staffArr = [
+      {
+        staff_id: 140081,
+        staff_fname: "Rahim",
+        staff_lname: "Khalid",
+        dept: "Sales",
+        position: "Sales Manager",
+        country: "Singapore",
+        email: "Rahim.khalid@allinone.com.sg",
+        reporting_manager: 160008,
+        role: 3,
+      },
+    ];
+    await Staff.insertMany(staffArr);
+    console.log("Staff data inserted successfully");
+  } catch (error) {
+    console.error("Error inserting staff data:", error);
+  }
+};

--- a/backend/tests/integration/staffCancelRequests.test.js
+++ b/backend/tests/integration/staffCancelRequests.test.js
@@ -1,4 +1,4 @@
-import { withdrawStaffRequests } from "../../api/controllers/arrangementRequestsController.js";
+import { cancelStaffRequests } from "../../api/controllers/arrangementRequestsController.js";
 import mongoose from "mongoose";
 import httpMocks from "node-mocks-http";
 import ArrangementRequest from "../../api/models/arrangementRequestsModel.js";
@@ -25,17 +25,15 @@ afterEach(async () => {
   await ArrangementRequest.deleteMany({});
 });
 
-describe("withdrawStaffRequests - Integration Test with MongoDB", () => {
+describe("cancelStaffRequests - Integration Test with MongoDB", () => {
   let req, res;
-  const reason = "Test withdrawal reason";
 
   beforeEach(() => {
     req = httpMocks.createRequest({
       method: "PATCH",
-      url: "/arrangementRequests/staffwithdrawal",
+      url: "/arrangementRequests/staffcancellation",
       body: {
         requests: [],
-        reason: reason,
       },
     });
     res = httpMocks.createResponse();
@@ -45,7 +43,7 @@ describe("withdrawStaffRequests - Integration Test with MongoDB", () => {
     const request1 = new ArrangementRequest({
       staff_id: 140881,
       request_date: new Date("2024-10-03T16:00:00.000Z"),
-      status: "Approved",
+      status: "Pending",
       manager_id: 140008,
       group_id: null,
       request_time: "PM",
@@ -55,25 +53,23 @@ describe("withdrawStaffRequests - Integration Test with MongoDB", () => {
 
     req.body.requests = [request1];
 
-    await withdrawStaffRequests(req, res);
+    await cancelStaffRequests(req, res);
 
     const response = res._getJSONData();
     expect(res.statusCode).toBe(200);
     expect(response.message).toBe(
-      "Requests have been withdrawed, pending manager approval"
+      "Requests have been cancelled successfully!"
     );
 
     const updatedRequest1 = await ArrangementRequest.findById(request1._id);
-
-    expect(updatedRequest1.status).toBe("Pending Withdrawal");
-    expect(updatedRequest1.withdraw_reason).toBe(reason);
+    expect(updatedRequest1.status).toBe("Cancelled");
   });
 
   test("should update the status of a regular request successfully", async () => {
     const request1 = new ArrangementRequest({
       staff_id: 140881,
       request_date: new Date("2024-10-03T16:00:00.000Z"),
-      status: "Approved",
+      status: "Pending",
       manager_id: 140008,
       group_id: null,
       request_time: "PM",
@@ -82,35 +78,55 @@ describe("withdrawStaffRequests - Integration Test with MongoDB", () => {
     const request2 = new ArrangementRequest({
       staff_id: 140881,
       request_date: new Date("2024-10-08T16:00:00.000Z"),
-      status: "Approved",
+      status: "Pending",
       manager_id: 140008,
       group_id: null,
       request_time: "PM",
       reason: "Personal reasons",
     });
+
     await request1.save();
     await request2.save();
 
     req.body.requests = [request1, request2];
 
-    await withdrawStaffRequests(req, res);
+    await cancelStaffRequests(req, res);
 
     const response = res._getJSONData();
     expect(res.statusCode).toBe(200);
     expect(response.message).toBe(
-      "Requests have been withdrawed, pending manager approval"
+      "Requests have been cancelled successfully!"
     );
 
     const updatedRequest1 = await ArrangementRequest.findById(request1._id);
     const updatedRequest2 = await ArrangementRequest.findById(request2._id);
 
-    expect(updatedRequest1.status).toBe("Pending Withdrawal");
-    expect(updatedRequest1.withdraw_reason).toBe(reason);
-    expect(updatedRequest2.status).toBe("Pending Withdrawal");
-    expect(updatedRequest2.withdraw_reason).toBe(reason);
+    expect(updatedRequest1.status).toBe("Cancelled");
+    expect(updatedRequest2.status).toBe("Cancelled");
   });
 
   test("should return a 500 if database error occurs", async () => {
+    req.body.requests = [
+      {
+        _id: "6707b42d5f19a670ff83aabb",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Pending",
+        manager_id: 140008,
+        group_id: null,
+        request_time: "PM",
+        reason: "Test request 1",
+        __v: 0,
+      },
+    ];
+    jest.spyOn(ArrangementRequest, "updateMany").mockImplementation(() => {
+      throw new Error("Database error");
+    });
+    await cancelStaffRequests(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  test("should return a 400 if request does not contain pending request", async () => {
     req.body.requests = [
       {
         _id: "6707b42d5f19a670ff83aabb",
@@ -125,29 +141,7 @@ describe("withdrawStaffRequests - Integration Test with MongoDB", () => {
         withdraw_reason: "cancel lagh",
       },
     ];
-    jest.spyOn(ArrangementRequest, "updateMany").mockImplementation(() => {
-      throw new Error("Database error");
-    });
-    await withdrawStaffRequests(req, res);
-    expect(res.statusCode).toBe(500);
-  });
-
-  test("should return a 400 if request does not contain approved request", async () => {
-    req.body.requests = [
-      {
-        _id: "6707b42d5f19a670ff83aabb",
-        staff_id: 140881,
-        request_date: "December 30, 2024",
-        status: "Pending",
-        manager_id: 140008,
-        group_id: null,
-        request_time: "PM",
-        reason: "Test request 1",
-        __v: 0,
-        withdraw_reason: "cancel lagh",
-      },
-    ];
-    await withdrawStaffRequests(req, res);
+    await cancelStaffRequests(req, res);
     expect(res.statusCode).toBe(400);
   });
 });

--- a/backend/tests/unit/controllers/arrangementRequests/staffCancelRequests.test.js
+++ b/backend/tests/unit/controllers/arrangementRequests/staffCancelRequests.test.js
@@ -1,0 +1,153 @@
+import {
+  cancelStaffRequests,
+  extractIdsWithStatus,
+} from "../../../../api/controllers/arrangementRequestsController";
+import httpMocks from "node-mocks-http";
+import ArrangementRequest from "../../../../api/models/arrangementRequestsModel";
+
+// Mocking the database model
+jest.mock("../../../../api/models/arrangementRequestsModel");
+
+describe("cancelStaffRequests - Unit Tests", () => {
+  let req, res;
+
+  beforeEach(() => {
+    req = httpMocks.createRequest({
+      method: "PATCH",
+      url: "/arrangementRequests/staffcancellation",
+      body: {
+        requests: [],
+      },
+    });
+    res = httpMocks.createResponse();
+  });
+
+  test("should return 200 and cancel request successfully for an ad-hoc request(happy case)", async () => {
+    ArrangementRequest.updateMany.mockResolvedValue({ modifiedCount: 1 });
+    const uncleanReq = [
+      {
+        _id: "6707b42d5f19a670ff83aabb",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Pending",
+        manager_id: 140008,
+        group_id: null,
+        request_time: "PM",
+        reason: "Test request 1",
+        __v: 0,
+      },
+    ];
+
+    req.body.requests = uncleanReq;
+    const cleanedRequestsId = extractIdsWithStatus(uncleanReq, "Pending");
+    await cancelStaffRequests(req, res);
+    expect(ArrangementRequest.updateMany).toHaveBeenCalledWith(
+      { _id: { $in: cleanedRequestsId } },
+      {
+        status: "Cancelled",
+      }
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  test("should return 200 and cancel requests successfully for a recurring regular request(happy case)", async () => {
+    ArrangementRequest.updateMany.mockResolvedValue({ modifiedCount: 1 });
+    const uncleanReq = [
+      {
+        _id: "6707b36f5f19a670ff83aab8",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Pending",
+        manager_id: 140008,
+        group_id: "testing",
+        request_time: "AM",
+        reason: "Test request 1",
+        __v: 0,
+      },
+      {
+        _id: "6707b4045f19a670ff83aab9",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Pending",
+        manager_id: 140008,
+        group_id: "testing",
+        request_time: "PM",
+        reason: "Test request 1",
+        __v: 0,
+      },
+    ];
+
+    req.body.requests = uncleanReq;
+
+    const cleanedRequestsId = extractIdsWithStatus(uncleanReq, "Pending");
+    await cancelStaffRequests(req, res);
+
+    expect(ArrangementRequest.updateMany).toHaveBeenCalledWith(
+      { _id: { $in: cleanedRequestsId } },
+      {
+        status: "Cancelled",
+      }
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  test("should return 400 if no requests are provided", async () => {
+    await cancelStaffRequests(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(res._getJSONData().message).toEqual(
+      "Please provide valid requests to cancel"
+    );
+  });
+
+  test("should return a 400 if none of the requests are Pending", async () => {
+    req.body.requests = req.body.requests = [
+      {
+        _id: "6707b36f5f19a670ff83aab8",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Approved",
+        manager_id: 140008,
+        group_id: "testing",
+        request_time: "AM",
+        reason: "Test request 1",
+        __v: 0,
+      },
+      {
+        _id: "6707b4045f19a670ff83aab9",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Cancelled",
+        manager_id: 140008,
+        group_id: "testing",
+        request_time: "PM",
+        reason: "Test request 1",
+        __v: 0,
+      },
+    ];
+
+    await cancelStaffRequests(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  test("should return 500 if database error occurs", async () => {
+    req.body.requests = [
+      {
+        _id: "6707b36f5f19a670ff83aab8",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Pending",
+        manager_id: 140008,
+        group_id: "testing",
+        request_time: "AM",
+        reason: "Test request 1",
+        __v: 0,
+      },
+    ];
+    ArrangementRequest.updateMany.mockRejectedValue(
+      new Error("Database error")
+    );
+    await cancelStaffRequests(req, res);
+    expect(res.statusCode).toBe(500);
+    expect(res._getJSONData()).toEqual({ message: "Internal server error" });
+  });
+});

--- a/backend/tests/unit/controllers/arrangementRequests/staffWithdrawRequests.test.js
+++ b/backend/tests/unit/controllers/arrangementRequests/staffWithdrawRequests.test.js
@@ -55,8 +55,8 @@ describe("withdrawStaffRequests - Unit Tests", () => {
     expect(res.statusCode).toBe(200);
   });
 
-  test("should return 200 and withdraw requests successfully for an ad-hoc request(happy case)", async () => {
-    ArrangementRequest.updateMany.mockResolvedValue({ modifiedCount: 1 });
+  test("should return 200 and withdraw requests successfully for a recurring regular request(happy case)", async () => {
+    ArrangementRequest.updateMany.mockResolvedValue({ modifiedCount: 2 });
     const uncleanReq = [
       {
         _id: "6707b36f5f19a670ff83aab8",
@@ -127,6 +127,36 @@ describe("withdrawStaffRequests - Unit Tests", () => {
     );
   });
 
+  test("should return a 400 if none of the requests are Approved", async () => {
+    req.body.requests = req.body.requests = [
+      {
+        _id: "6707b36f5f19a670ff83aab8",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Pending",
+        manager_id: 140008,
+        group_id: "testing",
+        request_time: "AM",
+        reason: "Test request 1",
+        __v: 0,
+      },
+      {
+        _id: "6707b4045f19a670ff83aab9",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Pending",
+        manager_id: 140008,
+        group_id: "testing",
+        request_time: "PM",
+        reason: "Test request 1",
+        __v: 0,
+      },
+    ];
+
+    await withdrawStaffRequests(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
   test("should return 500 if database error occurs", async () => {
     req.body.requests = [
       {
@@ -147,5 +177,140 @@ describe("withdrawStaffRequests - Unit Tests", () => {
     await withdrawStaffRequests(req, res);
     expect(res.statusCode).toBe(500);
     expect(res._getJSONData()).toEqual({ message: "Internal server error" });
+  });
+});
+
+describe("extractIdsWithStatus - Unit Tests", () => {
+  test("should return an empty array if all requests do not match the status", async () => {
+    const status = "Pending";
+    const uncleanReq = [
+      {
+        _id: "6707b42d5f19a670ff83aabb",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Approved",
+        manager_id: 140008,
+        group_id: null,
+        request_time: "PM",
+        reason: "Test request 1",
+        __v: 0,
+        withdraw_reason: "cancel lagh",
+      },
+      {
+        _id: "6707b42d5f19a670ff83aabb",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Cancelled",
+        manager_id: 140008,
+        group_id: null,
+        request_time: "PM",
+        reason: "Test request 1",
+        __v: 0,
+        withdraw_reason: "cancel lagh",
+      },
+    ];
+
+    const cleanedReq = extractIdsWithStatus(uncleanReq, status);
+    expect(cleanedReq.length).toBe(0);
+    expect(cleanedReq).toEqual([]);
+  });
+
+  test("should return an array of ids of length 2, if the reqArray contains 2 request which satisfy the status requirement", async () => {
+    const status = "Pending";
+    const uncleanReq = [
+      {
+        _id: "6707b42d5f19a670ff83aabb",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Approved",
+        manager_id: 140008,
+        group_id: null,
+        request_time: "PM",
+        reason: "Test request 1",
+        __v: 0,
+        withdraw_reason: "cancel lagh",
+      },
+      {
+        _id: "6707b42d5f19a670ff83aabb",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Pending",
+        manager_id: 140008,
+        group_id: null,
+        request_time: "PM",
+        reason: "Test request 1",
+        __v: 0,
+        withdraw_reason: "cancel lagh",
+      },
+      {
+        _id: "6737g42d5f12a670f283aabb",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Pending",
+        manager_id: 140008,
+        group_id: null,
+        request_time: "PM",
+        reason: "Test request 1",
+        __v: 0,
+        withdraw_reason: "cancel lagh",
+      },
+    ];
+
+    const cleanedReq = extractIdsWithStatus(uncleanReq, status);
+    expect(cleanedReq.length).toBe(2);
+    expect(cleanedReq).toEqual([
+      "6707b42d5f19a670ff83aabb",
+      "6737g42d5f12a670f283aabb",
+    ]);
+  });
+
+  test("should return an array of ids of length 2, if the reqArray contains 2 request which satisfy the status requirement", async () => {
+    const status = "Cancelled";
+    const uncleanReq = [
+      {
+        _id: "6707b02d5f12a670ff83aabb",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Cancelled",
+        manager_id: 140008,
+        group_id: null,
+        request_time: "PM",
+        reason: "Test request 1",
+        __v: 0,
+        withdraw_reason: "cancel lagh",
+      },
+      {
+        _id: "6707b42d5f19a670ff83aabb",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Cancelled",
+        manager_id: 140008,
+        group_id: null,
+        request_time: "PM",
+        reason: "Test request 1",
+        __v: 0,
+        withdraw_reason: "cancel lagh",
+      },
+      {
+        _id: "6737g42d5f12a670f283aabb",
+        staff_id: 140881,
+        request_date: "December 30, 2024",
+        status: "Cancelled",
+        manager_id: 140008,
+        group_id: null,
+        request_time: "PM",
+        reason: "Test request 1",
+        __v: 0,
+        withdraw_reason: "cancel lagh",
+      },
+    ];
+
+    const cleanedReq = extractIdsWithStatus(uncleanReq, status);
+    expect(cleanedReq.length).toBe(3);
+    expect(cleanedReq).toEqual([
+      "6707b02d5f12a670ff83aabb",
+      "6707b42d5f19a670ff83aabb",
+      "6737g42d5f12a670f283aabb",
+    ]);
   });
 });

--- a/frontend/src/components/Request.vue
+++ b/frontend/src/components/Request.vue
@@ -37,7 +37,13 @@
       </span>
     </td>
     <td class="p-4 text-gray-600">{{ node.request_time }}</td>
-    <td class="p-4 text-gray-600">{{ node.reason }}</td>
+    <td
+      class="p-4 text-gray-600"
+      v-if="node.status == 'Pending Withdrawal' || node.status == 'Withdrawn'"
+    >
+      {{ node.withdraw_reason }}
+    </td>
+    <td class="p-4 text-gray-600" v-else>{{ node.reason }}</td>
     <td class="p-4 text-gray-600">
       <span
         v-if="node.status == 'Pending'"
@@ -97,13 +103,19 @@
     <td class="ps-4"></td>
     <td v-if="invokingPage === 'Staff Request'" class="ps-4"></td>
     <td v-if="invokingPage === 'Staff Request'" class="ps-4"></td>
-    <td class="p-4" :class="{'pl-10': invokingPage === 'My Request'}">
+    <td class="p-4" :class="{ 'pl-10': invokingPage === 'My Request' }">
       <span class="flex items-center space-x-2">
         <span class="text-gray-800">{{ child.request_date }}</span>
       </span>
     </td>
     <td class="p-4 text-gray-600"></td>
-    <td class="p-4 text-gray-600"></td>
+    <td
+      class="p-4 text-gray-600"
+      v-if="child.status == 'Pending Withdrawal' || child.status == 'Withdrawn'"
+    >
+      {{ child.withdraw_reason }}
+    </td>
+    <td class="p-4 text-gray-600" v-else>{{ child.reason }}</td>
     <td class="p-4 text-gray-600">
       <span
         v-if="child.status == 'Pending'"

--- a/frontend/src/components/Requests.vue
+++ b/frontend/src/components/Requests.vue
@@ -257,13 +257,13 @@ export default {
         cleanedRequests = this.selectedRequest.filter((req) => req.status == 'Approved')
         this.withdrawArrangementRequests(cleanedRequests)
       } else if (event == 'Reject Request') {
-        console.log('reject req');
+        console.log('reject req')
       } else if (event == 'Approve Request') {
-        console.log('approve req');
+        console.log('approve req')
       } else if (event == 'Approve Withdrawal') {
-        console.log('approve withdrawal');
+        console.log('approve withdrawal')
       } else if (event == 'Reject Withdrawal') {
-        console.log('reject withdrawal');
+        console.log('reject withdrawal')
       }
       this.isOpenOptions = false
     },
@@ -359,7 +359,21 @@ export default {
     },
 
     async cancelArrangementRequests(reqArray) {
-      console.log(reqArray)
+      try {
+        const response = await axios.patch(
+          'http://localhost:3001/arrangementRequests/staffcancellation',
+          {
+            requests: reqArray,
+          }
+        )
+        if (response.status === 200) {
+          alert(response.data.message)
+          this.fetchArrangementRequests()
+        }
+      } catch (error) {
+        const errorMessage = error.response?.data?.message || error.message
+        alert(`Error - ${errorMessage}`)
+      }
     },
 
     /**
@@ -520,7 +534,7 @@ export default {
               year: 'numeric'
             })}`,
             children: value,
-            reason: value[0].reason,
+            // reason: value[0].reason,
             request_time: value[0].request_time,
             staff_name: value[0].staff_name,
             position: value[0].position
@@ -529,6 +543,7 @@ export default {
           requestsArr.push(...value)
         }
       }
+      console.log(requestsArr);
       return requestsArr
     },
 

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -94,7 +94,7 @@ export default {
           const { data } = response
           saveInStorage(data.data)
           alert('Successfully logged in!')
-          this.$router.push('/submittedview')
+          this.$router.push('/schedule')
         }
       } catch (error) {
         const errorMessage = error.response?.data?.message || error.message


### PR DESCRIPTION
This merge request contains the following:
1. Frontend component for cancel pending WFH arrangement (reuses Requests.vue and Request.vue)
2. Backend API endpoint for processing of cancellation of arrangement (processes both Regular + Ad Hoc in a single method)
3. Integration + unit tests for endpoint
4. Functional tests completed as well

Contains the following refinements:
1. Refinement to the Request.vue to show Withdrawal Reason IF Status = 'Pending Withdrawal' || Status = 'Withdrawn', ELSE show Arrangement Reason 
2. Refinement to the Navbar.vue to remove the old view request page (both staff and manager view).
3. The old view request pages should be removed from the repository once all code has been migrated out of it.